### PR TITLE
Added support for default (latest) version of catalog items

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,3 @@ cache:
 jdk:
   - oraclejdk8
   - openjdk8
-env:
-  global:
-    - VRA_URL=https://api.mgmt.cloud.vmware.com
-    - secure: "vTUDFgyfJpSY4Or+ToBYTu48eEdpKR4LDFRicaxG9TYE6Bgvw/Mc68bwh5cpLvcuFCKDsMavZk03fdfCK/o9hWYzzs/O8rOjBX4tq+RjibsQzRDrjMa9qzQVlxSmIy5/V8VDfIJQCD0hd8iZP5DW1O5Sywb153O+KhdRYqqpoDZkqZ9wpE2xOnpaTdriCzNteUXKyv5yH4u0GrSG8tJ4TB4lBEANo8uj9qKBDFEOqaYkky/Nb7tYXPBXGaRHHf+drMS6j7muYNoylUdCGAwlTyIY0JnuggNkSyhnKNt9OBo3+m3fmdEuwzFrp0P5IyEfZN7tE2vmn0Nt6Pnrk/A5vVj+ss0L8P/VnqpkMBJoe49nfb1znwn3MFDTYrRG61ytg0SUGuO0sNEcMulCaM5GqgW20D9WoovavtzQlgGyXZIokymL8TYwpJjN+YFioCWHz97gyf/OcNKG6AUNcjUVYGDOSHKf4+j2LA05ap1RQrT8bgbWJdsHrsB4qTrYBSllO9nU50guL1iuyag5rRRhZQ8h6MJpA9m/PfdTS4nqShI1msyKHIkB8PYX6VQNhAm9hhF7HV4GHLRpm8Jwfj7D4OQd88D1NZMucHhOA8aNWZ50huj4Mt5OopOLXZcO1COeyXWdovhwnzPWWm5tur5T6joZiaiIBMaCjMs1ZcXFrDM="

--- a/docs/vraDeployFromCatalog.md
+++ b/docs/vraDeployFromCatalog.md
@@ -1,15 +1,17 @@
 # Deploy from catalog
 
 ### Step name
+
 vraDeployFromCatalog
 
 ### Description
-Creates a new deployment based on a catalog item and ties it to a specified project.
-This step can be run in two modes: Either the details about the deployment are specified as 
-individual parameters, or they are supplied as a JSON or Yaml string. The latter is
-useful when you want to read the deployment specification from a file. 
+
+Creates a new deployment based on a catalog item and ties it to a specified project. This step can be run in two modes:
+Either the details about the deployment are specified as individual parameters, or they are supplied as a JSON or Yaml
+string. The latter is useful when you want to read the deployment specification from a file.
 
 ### Parameters
+
 | Name | Type | Description |
 |------|------|-------------|
 | vraUrl | String | URL to the vRealize Automation Instance (optional) |
@@ -20,27 +22,32 @@ useful when you want to read the deployment specification from a file.
 | trustSelfSignedCert | Boolean | Trust self-signed certificates (not recommended) |
 | projectName | String | The name of the associated vRealize Automation project |
 | catalogItemName | String | The name of the catalog item to deploy |
-| version | String | The version of the catalog item to deploy |
+| version | String | The version of the catalog item to deploy. If omitted, the latest version will be deployed |
 | deploymentName | String | The name of the deployment. (Optional. Generated if omitted) |
 | reason | String | The reason for the deployment. (Optional)
 | inputs | String or Map | Blueprint inputs. Key-value pairs encoded as a JSON string | 
 | count | Integer | Then number of copies of this catalog item to deploy |
-| config | String | The entire configuration of a catalog item as a JSON or Yaml string. Environment variable substitution is supported. Mutually exculsive with ```projectName```, ```catalogItemName```, ```deploymentName```, ```reason```, ```count``` and ```inputs```. 
+| config | String | The entire configuration of a catalog item as a JSON or Yaml string. Environment variable substitution is supported. Mutually exculsive with ```projectName```, ```catalogItemName```, ```deploymentName```, ```reason```, ```count``` and ```inputs```.
 | configFormat | String | The format of the config string. Allowed values are "yaml" or "json" |
 | timeout | Long | Timeout for the deletion to complete, in seconds (default: 300) |
 
 ### Return value
-Returns a list of maps corresponding to the fields of a [Deployment](https://prydin.github.io/vrealize-automation-plugin-for-jenkins/apidocs/com/vmware/vra/jenkinsplugin/model/catalog/Deployment.html). 
-The size of the array should match the supplied ```count``` parameter.
+
+Returns a list of maps corresponding to the fields of
+a [Deployment](https://prydin.github.io/vrealize-automation-plugin-for-jenkins/apidocs/com/vmware/vra/jenkinsplugin/model/catalog/Deployment.html)
+. The size of the array should match the supplied ```count``` parameter.
 
 ### Deployment naming
-Deployment names must be unique. When you omit the deployment name, a unique name is automatically generated. If you want
-a custom name and want to make sure it's unique, simply include a '#' character. This will be replaced with a UUID once
-the deployment is submitted. For example "MyDeployment-#" will expand to something similar to "MyDeployment-8F02D710-9312-4414-9B38-1BB315D8301D".
+
+Deployment names must be unique. When you omit the deployment name, a unique name is automatically generated. If you
+want a custom name and want to make sure it's unique, simply include a '#' character. This will be replaced with a UUID
+once the deployment is submitted. For example "MyDeployment-#" will expand to something similar to "
+MyDeployment-8F02D710-9312-4414-9B38-1BB315D8301D".
 
 ### vRealize Automation URL and token
-If the ```vraURL``` or ```token``` parameters are not specified, they are obtained from the 
-global settings (if present).
+
+If the ```vraURL``` or ```token``` parameters are not specified, they are obtained from the global settings (if present)
+.
 
 ### Examples
 
@@ -71,7 +78,7 @@ node {
 
 ```groovy
 node {
- def dep = vraDeployFromCatalog(
+    def dep = vraDeployFromCatalog(
             configFormat: "yaml",
             config: readFile("infrastructure.yaml"))
     assert dep != null
@@ -85,12 +92,13 @@ node {
 ```
 
 infrastructure.yaml
+
 ```yaml
 "catalogItemName": "jenkins-test"
 "version": "2"
 "projectName": "JenkinsTest"
 "deploymentName": "JenkinsFromYaml-#"
-"inputs": 
-    "username": "test"
+"inputs":
+  "username": "test"
 "count": 1
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>vrealize-automation-8</artifactId>
-    <version>1.3</version>
+    <version>1.4-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
         <revision>1.0</revision>
@@ -197,7 +197,7 @@
     </developers>
 
     <scm>
-        <tag>vrealize-automation-8-1.3</tag>
+        <tag>vrealize-automation-8-1.0</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>vrealize-automation-8</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>1.3</version>
     <packaging>hpi</packaging>
     <properties>
         <revision>1.0</revision>
@@ -197,7 +197,7 @@
     </developers>
 
     <scm>
-        <tag>vrealize-automation-8-1.0</tag>
+        <tag>vrealize-automation-8-1.3</tag>
     </scm>
 
     <repositories>

--- a/src/main/java/com/vmware/vra/jenkinsplugin/pipeline/DeployFromCatalogExecution.java
+++ b/src/main/java/com/vmware/vra/jenkinsplugin/pipeline/DeployFromCatalogExecution.java
@@ -97,7 +97,7 @@ public class DeployFromCatalogExecution extends SynchronousNonBlockingStepExecut
       response =
           client.deployFromCatalog(
               ValueCheckers.notBlank(c.getCatalogItemName(), "catalogItemName"),
-              ValueCheckers.notBlank(c.getVersion(), "version"),
+              c.getVersion(),
               ValueCheckers.notBlank(c.getProjectName(), "projectName"),
               processDeploymentName(c.getDeploymentName()),
               c.getReason(),
@@ -108,7 +108,7 @@ public class DeployFromCatalogExecution extends SynchronousNonBlockingStepExecut
       response =
           client.deployFromCatalog(
               ValueCheckers.notBlank(step.getCatalogItemName(), "catalogItemName"),
-              ValueCheckers.notBlank(step.getVersion(), "version"),
+              step.getVersion(),
               ValueCheckers.notBlank(step.getProjectName(), "projectName"),
               processDeploymentName(step.getDeploymentName()),
               step.getReason(),

--- a/src/test/java/com/vmware/vra/jenkinsplugin/GlobalConfigurationTest.java
+++ b/src/test/java/com/vmware/vra/jenkinsplugin/GlobalConfigurationTest.java
@@ -33,6 +33,7 @@ import com.cloudbees.plugins.credentials.domains.Domain;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlSelect;
 import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
+import com.vmware.vra.jenkinsplugin.testutils.HTMLUtils;
 import hudson.util.Secret;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
@@ -70,7 +71,8 @@ public class GlobalConfigurationTest {
           final HtmlForm config = r.createWebClient().goTo("configure").getFormByName("config");
           final HtmlTextInput textbox = config.getInputByName("_.vraURL");
           final HtmlSelect credential = config.getSelectByName("_.credentialId");
-          credential.setSelectedIndex(1);
+
+          HTMLUtils.setNamedOption(credential, "vraToken");
           textbox.setText("hello");
 
           r.submit(config);

--- a/src/test/java/com/vmware/vra/jenkinsplugin/pipeline/E2ETestBase.java
+++ b/src/test/java/com/vmware/vra/jenkinsplugin/pipeline/E2ETestBase.java
@@ -8,6 +8,7 @@ import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
 import com.vmware.vra.jenkinsplugin.testutils.FileUtils;
+import com.vmware.vra.jenkinsplugin.testutils.HTMLUtils;
 import hudson.util.Secret;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
@@ -42,7 +43,7 @@ public class E2ETestBase {
           final HtmlForm config = r.createWebClient().goTo("configure").getFormByName("config");
           final HtmlTextInput textbox = config.getInputByName("_.vraURL");
           textbox.setText(url);
-          config.getSelectByName("_.credentialId").setSelectedIndex(1);
+          HTMLUtils.setNamedOption(config.getSelectByName("_.credentialId"), "vraToken");
           r.submit(config);
 
           final String pipeline = FileUtils.loadResource(name);
@@ -81,7 +82,7 @@ public class E2ETestBase {
           final HtmlForm config = r.createWebClient().goTo("configure").getFormByName("config");
           final HtmlTextInput vraUrl = config.getInputByName("_.vraURL");
           vraUrl.setText(url);
-          config.getSelectByName("_.credentialId").setSelectedIndex(1);
+          HTMLUtils.setNamedOption(config.getSelectByName("_.credentialId"), "vraCredentials");
           r.submit(config);
 
           final String pipeline = FileUtils.loadResource(name);

--- a/src/test/java/com/vmware/vra/jenkinsplugin/testutils/HTMLUtils.java
+++ b/src/test/java/com/vmware/vra/jenkinsplugin/testutils/HTMLUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020 VMware, Inc
+ *
+ *  SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.vmware.vra.jenkinsplugin.testutils;
+
+import com.gargoylesoftware.htmlunit.html.HtmlSelect;
+
+public class HTMLUtils {
+  public static void setNamedOption(final HtmlSelect selector, final String name) {
+    selector.setSelectedAttribute(
+        selector.getOptions().stream()
+            .filter(o -> o.getText().equals(name))
+            .findFirst()
+            .orElseThrow(IllegalArgumentException::new),
+        true);
+  }
+}

--- a/src/test/java/com/vmware/vra/jenkinsplugin/vra/VraApiTest.java
+++ b/src/test/java/com/vmware/vra/jenkinsplugin/vra/VraApiTest.java
@@ -40,8 +40,10 @@ import com.google.gson.Gson;
 import com.vmware.vra.jenkinsplugin.model.catalog.CatalogItem;
 import com.vmware.vra.jenkinsplugin.model.catalog.CatalogItemRequest;
 import com.vmware.vra.jenkinsplugin.model.catalog.CatalogItemRequestResponse;
+import com.vmware.vra.jenkinsplugin.model.catalog.CatalogItemVersion;
 import com.vmware.vra.jenkinsplugin.model.catalog.Deployment;
 import com.vmware.vra.jenkinsplugin.model.catalog.PageOfCatalogItem;
+import com.vmware.vra.jenkinsplugin.model.catalog.PageOfCatalogItemVersion;
 import com.vmware.vra.jenkinsplugin.model.catalog.ResourceAction;
 import com.vmware.vra.jenkinsplugin.model.catalog.ResourceActionRequest;
 import com.vmware.vra.jenkinsplugin.model.deployment.DeploymentRequest;
@@ -281,6 +283,38 @@ public class VraApiTest {
     assertNotNull(proj);
     assertEquals(projectName, proj.getName());
     verify(mocked, times(1)).get(eq("/iaas/api/projects/" + projectId), any(), eq(Project.class));
+  }
+
+  @Test
+  public void testGetLatestVersionMocked() throws Exception {
+    final Gson gson = new Gson();
+    final PageOfCatalogItemVersion wanted =
+        gson.fromJson(
+            FileUtils.loadResource("/apiresults/PageOfCatalogItemVersion.json"),
+            PageOfCatalogItemVersion.class);
+    final VraClient mocked = mock(VraClient.class);
+    when(mocked.get(
+            eq("/catalog/api/items/" + catalogItemId + "/versions"),
+            any(),
+            eq(PageOfCatalogItemVersion.class)))
+        .thenReturn(wanted);
+    final VraApi client = new VraApi(mocked);
+    final CatalogItemVersion v = client.getLatestCatalogItemVersion(catalogItemId);
+    assertNotNull(v);
+    assertEquals("10", v.getId());
+  }
+
+  @Test
+  public void testGetLatestVersion() throws Exception {
+    final String url = System.getenv("VRA_URL");
+    if (url == null) {
+      System.err.println("VRA_URL not set. Skipping test");
+      return;
+    }
+    final VraApi client = new VraApi(url, System.getenv("VRA_TOKEN"), true);
+    final CatalogItemVersion v = client.getLatestCatalogItemVersion(catalogItemId);
+    assertNotNull(v);
+    assertEquals("11", v.getId());
   }
 
   @Test

--- a/src/test/resources/apiresults/PageOfCatalogItemVersion.json
+++ b/src/test/resources/apiresults/PageOfCatalogItemVersion.json
@@ -1,0 +1,45 @@
+{
+  "content": [
+    {
+      "id": "10",
+      "description": "",
+      "createdAt": "2021-03-04T16:09:43.627118Z"
+    }
+  ],
+  "pageable": {
+    "offset": 0,
+    "sort": {
+      "sorted": false,
+      "unsorted": true,
+      "empty": true
+    },
+    "queryInfo": {
+      "customOptions": {},
+      "expand": [],
+      "select": [],
+      "properties": [],
+      "sort": {
+        "sorted": false,
+        "unsorted": true,
+        "empty": true
+      }
+    },
+    "pageNumber": 0,
+    "pageSize": 20,
+    "paged": true,
+    "unpaged": false
+  },
+  "totalElements": 1,
+  "totalPages": 1,
+  "last": true,
+  "first": true,
+  "size": 20,
+  "number": 0,
+  "sort": {
+    "sorted": false,
+    "unsorted": true,
+    "empty": true
+  },
+  "numberOfElements": 1,
+  "empty": false
+}

--- a/src/test/resources/com/vmware/vra/jenkinsplugin/pipelines/DeployFromCatalog.groovy
+++ b/src/test/resources/com/vmware/vra/jenkinsplugin/pipelines/DeployFromCatalog.groovy
@@ -25,6 +25,7 @@
 package com.vmware.vra.jenkinsplugin.pipelines
 
 node {
+    // Version omitted. Should pick latest.
     def dep = vraDeployFromCatalog(
             trustSelfSignedCert: true,
             catalogItemName: 'jenkins-test',
@@ -33,7 +34,6 @@ node {
             projectName: 'JenkinsTest',
             reason: 'Test',
             timeout: 300,
-            version: '6',
             inputs: '{ username: \'testuser\' }')
     assert dep != null
     def addr = vraWaitForAddress(

--- a/src/test/resources/com/vmware/vra/jenkinsplugin/pipelines/DeployFromCatalog.groovy
+++ b/src/test/resources/com/vmware/vra/jenkinsplugin/pipelines/DeployFromCatalog.groovy
@@ -33,7 +33,7 @@ node {
             projectName: 'JenkinsTest',
             reason: 'Test',
             timeout: 300,
-            version: '2',
+            version: '6',
             inputs: '{ username: \'testuser\' }')
     assert dep != null
     def addr = vraWaitForAddress(

--- a/src/test/resources/com/vmware/vra/jenkinsplugin/pipelines/DeployFromCatalogNoGlobalSettings.groovy
+++ b/src/test/resources/com/vmware/vra/jenkinsplugin/pipelines/DeployFromCatalogNoGlobalSettings.groovy
@@ -34,7 +34,7 @@ node {
             projectName: 'JenkinsTest',
             reason: 'Test',
             timeout: 300,
-            version: '2',
+            version: '6',
             inputMap: [username: 'testuser'])
     assert dep != null
     def addr = vraWaitForAddress(

--- a/src/test/resources/com/vmware/vra/jenkinsplugin/pipelines/DeployFromCatalogWithConfigJson.groovy
+++ b/src/test/resources/com/vmware/vra/jenkinsplugin/pipelines/DeployFromCatalogWithConfigJson.groovy
@@ -28,7 +28,7 @@ node {
     def config = """
 {
   "catalogItemName": "jenkins-test",
-  "version": "2",
+  "version": "6",
   "projectName": "JenkinsTest",
   "deploymentName": "JenkinsFromJson-#",
   "inputs": {

--- a/src/test/resources/com/vmware/vra/jenkinsplugin/pipelines/DeployFromCatalogWithConfigYaml.groovy
+++ b/src/test/resources/com/vmware/vra/jenkinsplugin/pipelines/DeployFromCatalogWithConfigYaml.groovy
@@ -27,7 +27,7 @@ package com.vmware.vra.jenkinsplugin.pipelines
 node {
     def config = """
 "catalogItemName": "jenkins-test"
-"version": "3"
+"version": "6"
 "projectName": "JenkinsTest"
 "deploymentName": "JenkinsFromYaml-#"
 "inputs": 
@@ -43,7 +43,7 @@ node {
             deploymentId: dep[0].id,
             resourceName: 'UbuntuMachine')
     echo "Deployed: $dep[0].id, addresses: $addr"
-    
+
     // Power off the machine
     def dep2 = vraRunAction(
             deploymentId: dep[0].id,


### PR DESCRIPTION
* If no version is specified when deploying a catalog item, the latest one is picked.
* Removed "TODO" from plugin title.
* Removed full test suite from Travis dues to secret management issues.